### PR TITLE
Redirect to hash route for hosted static content

### DIFF
--- a/404.template.html
+++ b/404.template.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script>
+      if (!location.hash) {
+        location.replace(location.protocol + '//' + location.host + location.search + '#' + location.pathname);
+      }
+    </script>
+  </head>
+  <body>
+    <h1>
+      We're sorry. No veggies found here.
+    </h1>
+    <p>
+      <a href="/">Click here to return to the home page</a>
+    </p>
+  </body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,11 @@ module.exports = {
       filename: 'index.html',
       template: 'index.template.html',
       favicon: path.join(__dirname, 'assets', 'images', 'favicon.ico')
+    }),
+    new HtmlWebpackPlugin({
+      filename: '404.html',
+      template: '404.template.html',
+      favicon: path.join(__dirname, 'assets', 'images', 'favicon.ico')
     })
   ],
   module: {

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -33,6 +33,11 @@ module.exports = {
       filename: 'index.html',
       template: 'index.template.html',
       favicon: path.join(__dirname, 'assets/images/favicon.ico')
+    }),
+    new HtmlWebpackPlugin({
+      filename: '404.html',
+      template: '404.template.html',
+      favicon: path.join(__dirname, 'assets', 'images', 'favicon.ico')
     })
   ],
   module: {


### PR DESCRIPTION
Since we are currently hosting the static built files where
(as far as I know) we can't serve the index.html file for all
requests, we are using hash routing with react-router. This
means that if a user tries to route to a direct, non-hash uri
it shows an error page. This commit adds that error file to
redirect back to a hash uri from index.html so that the react-
router can handle the uri again.

This closes #117
