### PR TITLE
Set the api url for production deployments.

### DIFF
--- a/lib/ApiClient.js
+++ b/lib/ApiClient.js
@@ -66,7 +66,7 @@ class ApiClient_ {
 
     // This assumes they are served from the same place
     if (process.env.NODE_ENV === 'production') {
-      url = versionedApiPath;
+      url = process.env.API_URL + versionedApiPath;
     }
     else if (process.env.USE_LOCAL_SERVER) {
       // NOTE: This requires CORS on server

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -18,7 +18,8 @@ module.exports = {
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
       'process.env': {
-        'NODE_ENV': '"production"'
+        'NODE_ENV': JSON.stringify('production'),
+        'API_URL': process.env.API_URL || 'http://api.freshfoodconnect.org'
       },
       '__DEVTOOLS__': false,
       '__CLIENT_HOST__': '"https://www.freshfoodconnect.org"'


### PR DESCRIPTION
For production deployments (using webpack.config.production.js), allow to set
API_URL env variable or use http://api.freshfoodconnect.org (no https yet).
