### PR TITLE
Notify users on all server errors

### DIFF
--- a/lib/actions/authActions.js
+++ b/lib/actions/authActions.js
@@ -31,7 +31,6 @@ export function login(email, password) {
         password
       }
     })
-    .catch(err => alert(err))
   };
 }
 
@@ -45,7 +44,6 @@ export function logout() {
       .then(() => {
         storage.remove('ffc-token');
       })
-      .catch(err => alert(err))
   };
 }
 

--- a/lib/actions/userActions.js
+++ b/lib/actions/userActions.js
@@ -16,6 +16,5 @@ export function setDonationPreference({locationId, userId, size, comments}) {
         }
       }
     })
-    .catch(err => alert(err))
   };
 }

--- a/lib/middleware/apiPromise.js
+++ b/lib/middleware/apiPromise.js
@@ -14,7 +14,10 @@ export default function createApiPromise(client) {
       next({...rest, type: REQUEST});
       return promise(client).then(
         (result) => next({...rest, result, type: SUCCESS}),
-        (error) => next({...rest, error, type: FAILURE})
+        (error) => {
+          alert(error);
+          next({...rest, error, type: FAILURE});
+        }
       );
     };
   };


### PR DESCRIPTION
This is obviously not ideal, however, it is better to
at least notify the user that something has happened
than have no information as to why something is failing.

Alerting here means that all server errors are handled,
and it doesn't reset the promise chain, which was causing
the redux state to be corrupted.

Connects to #114 
