### PR TITLE
Added basic signup wizard

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -4,6 +4,7 @@ https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-pract
 */
 html {
   box-sizing: border-box;
+  height: 100%;
 }
 
 *, *:before, *:after {

--- a/lib/components/LocationCard.js
+++ b/lib/components/LocationCard.js
@@ -12,7 +12,7 @@ export default class LocationCard extends Component {
   static propTypes = {
     apiLocation: PropTypes.object,
     saveLocation: PropTypes.func.isRequired,
-    userId: PropTypes.number.isRequired
+    userId: PropTypes.number
   }
 
   constructor(props) {

--- a/lib/components/PickupInfoCard.js
+++ b/lib/components/PickupInfoCard.js
@@ -1,0 +1,19 @@
+import React, {Component, PropTypes} from 'react';
+import {Card} from 'material-ui';
+
+export default class PickupInfoCard extends Component {
+  static propTypes = {
+    pickupDay: PropTypes.string.isRequired
+  }
+
+  render() {
+    return (
+      <Card style={{margin: '26px 20px',
+                      padding: '0 20px'}}>
+        <h2>
+          We pick up in your area on <em>{this.props.pickupDay}</em>
+        </h2>
+      </Card>
+    );
+  }
+}

--- a/lib/components/SignupCard.js
+++ b/lib/components/SignupCard.js
@@ -1,0 +1,86 @@
+import React, {Component, PropTypes} from 'react';
+import {Link} from 'react-router';
+import {
+  Card,
+  FlatButton,
+  RaisedButton,
+  Snackbar,
+  TextField
+} from 'material-ui';
+
+import signupValidation from '../validation/signupValidation';
+
+export default class SignupCard extends Component {
+  static propTypes = {
+    signup: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      email: '',
+      password: ''
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <Card style={{margin: '76px 20px',
+                      padding: '0 20px'}}>
+          <form onSubmit={this.handleSubmit}>
+            <TextField
+                floatingLabelText="Email"
+                value={this.state.email}
+                onChange={this._updateInputState.bind(this, 'email')} />
+            <br/>
+            <TextField
+                floatingLabelText="Password"
+                hintText="Password Field"
+                type="password"
+                value={this.state.password}
+                onChange={this._updateInputState.bind(this, 'password')}/>
+            <br/>
+            <RaisedButton label="Sign Up" onClick={this.handleSubmit.bind(this)}/>
+
+            <p>
+              Have an account already?
+              <Link to="login">
+                <FlatButton label="Log In" secondary={true}/>
+              </Link>
+            </p>
+          </form>
+        </Card>
+
+        <Snackbar
+            ref="snackbar"
+            message="Requires: a valid email and password with 8 or more characters."
+            autoHideDuration={3000}
+            className="snackbar"/>
+      </div>
+    );
+  }
+
+  _updateInputState(key, event) {
+    this.setState({
+      [key]: event.target.value
+    });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+
+    const { email, password } = this.state;
+
+    const validation = signupValidation({
+      email,
+      password
+    });
+
+    if (validation.valid) {
+      this.props.signup({email, password});
+    } else {
+      this.refs.snackbar.show();
+    }
+  }
+}

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -7,3 +7,4 @@ export GotVeggies from './views/GotVeggies';
 export GotNoVeggies from './views/GotNoVeggies';
 export NewPassword from './views/NewPassword';
 export SignUp from './views/SignUp';
+export SignupWizard from './views/SignupWizard';

--- a/lib/components/views/SignUp.js
+++ b/lib/components/views/SignUp.js
@@ -1,17 +1,9 @@
 import React, {Component, PropTypes} from 'react';
-import {Link} from 'react-router';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import {
-  Card,
-  FlatButton,
-  RaisedButton,
-  Snackbar,
-  TextField
-} from 'material-ui';
 
 import * as authActions from '../../actions/authActions';
-import signupValidation from '../../validation/signupValidation';
+import SignupCard from '../SignupCard';
 
 @connect(
   () => ({}),
@@ -22,74 +14,14 @@ export default class SignUp extends Component {
     signup: PropTypes.func
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      email: '',
-      password: ''
-    };
-  }
-
   render() {
     return (
       <div>
-        <Card style={{margin: '76px 20px',
-                      padding: '0 20px'}}>
-          <h1>Sign Up</h1>
-
-          <form onSubmit={this.handleSubmit}>
-            <TextField
-                floatingLabelText="Email"
-                value={this.state.email}
-                onChange={this._updateInputState.bind(this, 'email')} />
-            <br/>
-            <TextField
-                floatingLabelText="Password"
-                hintText="Password Field"
-                type="password"
-                value={this.state.password}
-                onChange={this._updateInputState.bind(this, 'password')}/>
-            <br/>
-            <RaisedButton label="Sign Up" onClick={this.handleSubmit.bind(this)}/>
-
-            <p>
-              Have an account already?
-              <Link to="login">
-                <FlatButton label="Log In" secondary={true}/>
-              </Link>
-            </p>
-          </form>
-        </Card>
-
-        <Snackbar
-            ref="snackbar"
-            message="Requires: a valid email and password with 8 or more characters."
-            autoHideDuration={3000}
-            className="snackbar"/>
+        <h1 className="pageTitle text-center">
+          Sign Up
+        </h1>
+        <SignupCard signup={this.props.signup} />
       </div>
     );
-  }
-
-  _updateInputState(key, event) {
-    this.setState({
-      [key]: event.target.value
-    });
-  }
-
-  handleSubmit(event) {
-    event.preventDefault();
-
-    const { email, password } = this.state;
-
-    const validation = signupValidation({
-      email,
-      password
-    });
-
-    if (validation.valid) {
-      this.props.signup({email, password});
-    } else {
-      this.refs.snackbar.show();
-    }
   }
 }

--- a/lib/components/views/SignupWizard.js
+++ b/lib/components/views/SignupWizard.js
@@ -1,0 +1,83 @@
+import React, {Component, PropTypes} from 'react';
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import LocationCard from '../LocationCard';
+import PickupInfoCard from '../PickupInfoCard';
+import SignupCard from '../SignupCard';
+import {signup} from '../../actions/authActions';
+import {updateLocation} from '../../actions/locationActions';
+
+
+@connect(
+  state => ({user: state.auth.user}),
+  dispatch => bindActionCreators({signup, updateLocation}, dispatch)
+)
+export default class SignupWizard extends Component {
+  static propTypes = {
+    signup: PropTypes.func.isRequired,
+    updateLocation: PropTypes.func.isRequired,
+    user: PropTypes.object
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      location: null
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.user && nextProps.user && this.state.location) {
+      this.props.updateLocation(this.state.location, nextProps.user.id);
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <h1 className="pageTitle text-center">
+          Where do you live?
+        </h1>
+        <LocationCard saveLocation={this._storeLocation.bind(this)}/>
+        {this.state.location ? this._getPickupDetails() : null}
+        {this.state.location ? this._getEmailSignup.call(this) : null}
+      </div>
+    );
+  }
+
+  _storeLocation(location) {
+    this.setState({
+      location
+    });
+  }
+
+  _getPickupDetails() {
+    // We can check if the zipcode / location is in a place
+    // where they pickup currently here
+    // Also, this is where we would check the api for the actual
+    // pickup day associated with that location
+    const pickupDay = 'Tuesday';
+    return (
+      <PickupInfoCard pickupDay={pickupDay} />
+    );
+  }
+
+  _getEmailSignup() {
+    return (
+      <div>
+        <h2 className="text-center" style={{color: 'white'}}>
+          Now we just need a way to contact you
+        </h2>
+        <h3 className="text-center" style={{color: 'white'}}>
+          and an email so you can update your preferences
+        </h3>
+        <p className="text-center" style={{color: 'white'}}>
+          You will receive an email the day before a pickup to check if you have food to donate.
+        </p>
+        <SignupCard signup={this.props.signup}/>
+      </div>
+    );
+  }
+}

--- a/lib/components/views/SignupWizard.js
+++ b/lib/components/views/SignupWizard.js
@@ -8,6 +8,8 @@ import SignupCard from '../SignupCard';
 import {signup} from '../../actions/authActions';
 import {updateLocation} from '../../actions/locationActions';
 
+import {PICKUP_TIME} from '../../constants';
+
 
 @connect(
   state => ({user: state.auth.user}),
@@ -58,7 +60,7 @@ export default class SignupWizard extends Component {
     // where they pickup currently here
     // Also, this is where we would check the api for the actual
     // pickup day associated with that location
-    const pickupDay = 'Tuesday';
+    const pickupDay = PICKUP_TIME;
     return (
       <PickupInfoCard pickupDay={pickupDay} />
     );

--- a/lib/components/views/UserProfile.js
+++ b/lib/components/views/UserProfile.js
@@ -5,13 +5,11 @@ import {login} from '../../actions/authActions';
 import {getLocation, updateLocation} from '../../actions/locationActions';
 import {
   Card,
-  Checkbox,
-  RaisedButton,
-  TextField,
-  TimePicker
+  RaisedButton
 } from 'material-ui';
 
 import LocationCard from '../LocationCard';
+import PickupInfoCard from '../PickupInfoCard';
 
 @connect(
   state => ({
@@ -49,6 +47,7 @@ export default class UserProfile extends Component {
   render() {
     const {user} = this.props;
     const styles = require('./Login.scss');
+    const pickupDay = 'Tuesday';
 
     return (
       <div className={styles.loginPage}>
@@ -63,26 +62,9 @@ export default class UserProfile extends Component {
               saveLocation={this.props.updateLocation}
               apiLocation={this.props.apiLocation}/>
 
-          <Card style={{margin: '20px',
-                        padding: '0 20px'}}>
-            <h2>
-              Pickup Time
-            </h2>
-            <span>
-              Your pickup time is:
-              <div style={{display: 'inline-block', padding: '0 5px'}}>
-                <TimePicker ref="timeSelector"
-                    defaultTime={new Date('Tues Aug 25 3:00:00 pm')}
-                    format="ampm"
-                    hintText="12hr Format"
-                    pedantic={true}
-                    onChange={::this._handleTimeChange}
-                    style={{width: '5rem'}}/>
-              </div>
-              <em>Tuesday</em>
-            </span>
-          </Card>
+          <PickupInfoCard pickupDay={pickupDay} />
 
+          {/* can add this back when we actually persist and use the data
           <Card style={{margin: '20px',
                         padding: '0 20px'}}>
             <h2>
@@ -99,7 +81,7 @@ export default class UserProfile extends Component {
                 floatingLabelText="Additional Notes"
                 defaultValue={"\n\n\n"}
                 multiLine={true} />
-          </Card>
+          </Card>*/}
         </div>
         }
 
@@ -117,9 +99,5 @@ export default class UserProfile extends Component {
         }
       </div>
     );
-  }
-
-  _handleTimeChange(err, t) {
-    this.refs.timeSelector.setTime(t);
   }
 }

--- a/lib/components/views/UserProfile.js
+++ b/lib/components/views/UserProfile.js
@@ -11,6 +11,9 @@ import {
 import LocationCard from '../LocationCard';
 import PickupInfoCard from '../PickupInfoCard';
 
+import {PICKUP_TIME} from '../../constants';
+
+
 @connect(
   state => ({
     user: state.auth.user,
@@ -47,7 +50,7 @@ export default class UserProfile extends Component {
   render() {
     const {user} = this.props;
     const styles = require('./Login.scss');
-    const pickupDay = 'Tuesday';
+    const pickupDay = PICKUP_TIME;
 
     return (
       <div className={styles.loginPage}>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -49,3 +49,6 @@ export const NEW_PASSWORD_FAIL = 'NEW_PASSWORD_FAIL';
 export const USER_SET_DONATION_PREFERENCE = 'USER_SET_DONATION_PREFERENCE';
 export const USER_SET_DONATION_PREFERENCE_SUCCESS = 'USER_SET_DONATION_PREFERENCE_SUCCESS';
 export const USER_SET_DONATION_PREFERENCE_FAIL = 'USER_SET_DONATION_PREFERENCE_FAIL';
+
+// Temp hard coded variable until we integrate properly with back end
+export const PICKUP_TIME = 'Thursdays from 8 till noon';

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -13,7 +13,7 @@ import {
   GotNoVeggies,
   GotVeggies,
   NewPassword,
-  SignUp
+  SignupWizard
 } from './components';
 
 import Admin from './components/views/Admin';
@@ -31,7 +31,7 @@ export function renderRoutes(history, store) {
         <Route path="/login" component={Login}/>
         <Route path="/confirm-donation" component={GotVeggies} onEnter={requireAuth(store)}/>
         <Route path="/sorrynotthistime" component={GotNoVeggies} onEnter={requireAuth(store)}/>
-        <Route path="/signup" component={SignUp}/>
+        <Route path="/signup" component={SignupWizard}/>
         <Route path="/reset-password" component={ForgotPassword}/>
         <Route path="/reset" component={NewPassword}/>
         <Route path="/profile" component={UserProfile} onEnter={requireAuth(store)}/>


### PR DESCRIPTION
The process of saving the address and then persisting it after
the user is created is pretty hacky, and should probably be updated

This works in it's current form with @mpfilbin's [confirmable_workaround](https://github.com/codefordenver/fresh-food-connect-api/tree/confirmable_workaround) branch, however, we need to figure out the plan for #145 before we add this.
