### PR TITLE
Stop routing to home on navbar close

### DIFF
--- a/lib/components/Navbar.js
+++ b/lib/components/Navbar.js
@@ -72,7 +72,7 @@ class Navbar extends Component {
             <Link to="/">
               <img alt="Fresh Food Connect" src={image} />
             </Link>
-            <a href="#" className="custom-toggle" id="toggle"><s className="bar"></s><s className="bar"></s></a>
+            <a className="custom-toggle" id="toggle"><s className="bar"></s><s className="bar"></s></a>
           </div>
         </div>
         <div className="navigation__menu">


### PR DESCRIPTION
Closes #155 

The routing uses a hash manager for prod's static
file serving. This fixes a bug with the navbar
implementation and this hash routing.
