### PR TITLE
Fix nav bar styling issue

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -39,3 +39,7 @@ body {
 .pure-menu-horizontal .pure-menu-item {
   margin-left: 50px;
 }
+
+#menu:not(.open) .pure-menu-list {
+  height: 0;
+}


### PR DESCRIPTION
The 'Home' text on the menu was partially visible
behind the logo image. Looking super weird
![image](https://cloud.githubusercontent.com/assets/5432102/10358870/06b93a02-6d50-11e5-9b0c-fb65c8b3a8ba.png)
